### PR TITLE
Updated rvm_gem.rb

### DIFF
--- a/lib/puppet/type/rvm_gem.rb
+++ b/lib/puppet/type/rvm_gem.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:rvm_gem) do
   @doc = "Ruby Gem support using RVM."
 
   def self.title_patterns
-    [ [ /^(?:(.*)\/)?(.*)$/, [ [ :ruby_version, lambda{|x| x} ], [ :name, lambda{|x| x} ] ] ] ]
+    [ [ /^(?:(.*)\/)?(.*)$/, [ [ :ruby_version ], [ :name ] ] ] ]
   end
 
   ensurable do


### PR DESCRIPTION
Fixing issues regarding `puppet generate types` where this file cannot be created because of `title patterns that use procs are not supported`.